### PR TITLE
router: pass a copy of complex event fields to each local peer

### DIFF
--- a/router/broker.go
+++ b/router/broker.go
@@ -529,18 +529,22 @@ func (b *broker) syncPubEvent(pub *wamp.Session, msg *wamp.Publish, pubID wamp.I
 		}
 
 		if subscriber.Peer.IsLocal() {
-			if len(event.Details) != 0 {
+			// the local handler may be lousy and may try to modify
+			// either of those fields, make sure that each event
+			// carries a copy of the respective structure, even if
+			// it's empty
+			if event.Details != nil {
 				options := make(map[string]interface{}, len(event.Details))
 				for k, v := range msg.Options {
 					options[k] = v
 				}
 				event.Details = options
 			}
-			if len(msg.Arguments) != 0 {
+			if msg.Arguments != nil {
 				event.Arguments = make([]interface{}, len(msg.Arguments))
 				copy(event.Arguments, msg.Arguments)
 			}
-			if len(msg.ArgumentsKw) != 0 {
+			if msg.ArgumentsKw != nil {
 				argsKw := make(map[string]interface{}, len(msg.ArgumentsKw))
 				for k, v := range msg.ArgumentsKw {
 					argsKw[k] = v


### PR DESCRIPTION
A copy of complex event fields (options, args, kwargs) should be made when those are non-nil rather than non-empty. This ensures that if a funny handler assigns to one of the fields, it only does so in its private copy.
